### PR TITLE
hotfix for streaming claude search error

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -27,7 +27,7 @@ keywords = nbdev jupyter notebook python
 language = English
 status = 3
 user = AnswerDotAI
-requirements = litellm numpydoc toolslm fastcore>=1.8.13
+requirements = litellm<=1.80.5 numpydoc toolslm fastcore>=1.8.13
 dev_requirements = ipython pycachy>=0.0.4 fastlite
 cell_number = False
 readme_nb = index.ipynb


### PR DESCRIPTION
Litellm 1.80.6 includes search results in tool calls, this is currently not supported so this hotfix pins litellm to 1.80.5.