### PR TITLE
fix native tool schemas in func call

### DIFF
--- a/lisette/core.py
+++ b/lisette/core.py
@@ -223,7 +223,7 @@ class ToolResponse:
 
 # %% ../nbs/00_core.ipynb
 def _lite_call_func(tc, tool_schemas, ns, raise_on_err=True):
-    fn, valid = tc.function.name, {o['function']['name'] for o in tool_schemas or []}
+    fn, valid = tc.function.name, {nested_idx(o,'function','name') for o in tool_schemas or []}
     if fn not in valid: res = f"Tool not defined in tool_schemas: {fn}"
     else:
         try: res = call_func(fn, json.loads(tc.function.arguments), ns=ns)
@@ -417,7 +417,7 @@ def mk_tc_results(tcq, results): return [mk_tc_result(a,b) for a,b in zip(tcq.to
 
 # %% ../nbs/00_core.ipynb
 async def _alite_call_func(tc, tool_schemas, ns, raise_on_err=True):
-    fn, valid = tc.function.name, {o['function']['name'] for o in tool_schemas or []}
+    fn, valid = tc.function.name, {nested_idx(o,'function','name') for o in tool_schemas or []}
     if fn not in valid: res = f"Tool not defined in tool_schemas: {fn}"
     else:
         try: fargs = json.loads(tc.function.arguments)

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -1862,7 +1862,7 @@
    "source": [
     "#| export\n",
     "def _lite_call_func(tc, tool_schemas, ns, raise_on_err=True):\n",
-    "    fn, valid = tc.function.name, {o['function']['name'] for o in tool_schemas or []}\n",
+    "    fn, valid = tc.function.name, {nested_idx(o,'function','name') for o in tool_schemas or []}\n",
     "    if fn not in valid: res = f\"Tool not defined in tool_schemas: {fn}\"\n",
     "    else:\n",
     "        try: res = call_func(fn, json.loads(tc.function.arguments), ns=ns)\n",
@@ -6250,7 +6250,7 @@
    "source": [
     "#| export\n",
     "async def _alite_call_func(tc, tool_schemas, ns, raise_on_err=True):\n",
-    "    fn, valid = tc.function.name, {o['function']['name'] for o in tool_schemas or []}\n",
+    "    fn, valid = tc.function.name, {nested_idx(o,'function','name') for o in tool_schemas or []}\n",
     "    if fn not in valid: res = f\"Tool not defined in tool_schemas: {fn}\"\n",
     "    else:\n",
     "        try: fargs = json.loads(tc.function.arguments)\n",
@@ -7546,13 +7546,7 @@
    "source": []
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "python3",
-   "language": "python",
-   "name": "python3"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }


### PR DESCRIPTION
This PR gets `schema.function.name` from `tool_schemas` gracefully to handle native tool schemas such as Gemini's `[{"urlContext": {}}]`. In the case of a model tool call hallucination current code breaks with a `KeyError:'function'`, this PR fixes that.


Fixes https://github.com/AnswerDotAI/lisette/issues/77