### PR TITLE
display generated imgs

### DIFF
--- a/lisette/core.py
+++ b/lisette/core.py
@@ -61,6 +61,7 @@ def _repr_markdown_(self: litellm.ModelResponse):
     if message.tool_calls:
         tool_calls = [f"\n\n🔧 {nested_idx(tc,'function','name')}({nested_idx(tc,'function','arguments')})\n" for tc in message.tool_calls]
         content += "\n".join(tool_calls)
+    for img in getattr(message, 'images', []): content += f"\n\n![generated image]({nested_idx(img, 'image_url', 'url')})"
     if not content: content = str(message)
     details = [
         f"id: `{self.id}`",
@@ -535,6 +536,7 @@ class StreamFormatter:
             elif self.outp and self.outp[-1] == '🧠': res+= '\n\n'
             if c:=d.content: # gemini has text content in last reasoning chunk
                 res+=f"\n\n{c}" if res and res[-1] == '🧠' else c
+            for img in getattr(d, 'images', []): res += f"\n\n![generated image]({nested_idx(img, 'image_url', 'url')})\n\n"
         elif isinstance(o, ModelResponse):
             if self.include_usage: res += f"\nUsage: {o.usage}"
             if c:=getattr(contents(o),'tool_calls',None):

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -181,6 +181,7 @@
     "    if message.tool_calls:\n",
     "        tool_calls = [f\"\\n\\n🔧 {nested_idx(tc,'function','name')}({nested_idx(tc,'function','arguments')})\\n\" for tc in message.tool_calls]\n",
     "        content += \"\\n\".join(tool_calls)\n",
+    "    for img in getattr(message, 'images', []): content += f\"\\n\\n![generated image]({nested_idx(img, 'image_url', 'url')})\"\n",
     "    if not content: content = str(message)\n",
     "    details = [\n",
     "        f\"id: `{self.id}`\",\n",
@@ -415,6 +416,24 @@
     "for m in ms:\n",
     "    display(Markdown(f'**{m}:**'))\n",
     "    display(completion(m,msg))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4841816e",
+   "metadata": {},
+   "source": [
+    "Generated images are also displayed (not shown here to conserve filesize):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6a027b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# completion(model='gemini/gemini-2.5-flash-image', messages=[{'role':'user','content':'Draw a simple sketch of a cat'}])"
    ]
   },
   {
@@ -6618,6 +6637,7 @@
     "            elif self.outp and self.outp[-1] == '🧠': res+= '\\n\\n'\n",
     "            if c:=d.content: # gemini has text content in last reasoning chunk\n",
     "                res+=f\"\\n\\n{c}\" if res and res[-1] == '🧠' else c\n",
+    "            for img in getattr(d, 'images', []): res += f\"\\n\\n![generated image]({nested_idx(img, 'image_url', 'url')})\\n\\n\"\n",
     "        elif isinstance(o, ModelResponse):\n",
     "            if self.include_usage: res += f\"\\nUsage: {o.usage}\"\n",
     "            if c:=getattr(contents(o),'tool_calls',None):\n",
@@ -6785,6 +6805,25 @@
     "        md+=o\n",
     "        display(Markdown(md),clear=True)\n",
     "    return fmt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "024f48c3",
+   "metadata": {},
+   "source": [
+    "Generated images can be displayed in streaming too (not shown here to conserve filesize):\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8611f80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# rs = completion(model='gemini/gemini-2.5-flash-image', stream=True, messages=[{'role':'user','content':'Draw a simple sketch of a dog'}])\n",
+    "# fmt = display_stream(rs)"
    ]
   },
   {


### PR DESCRIPTION
replaces #55 cleaner to start w new branch

Here's example use in solveit w `gemini/gemini-3-pro-image-preview` ... lot of tokens though 😅.

<img width="528" height="494" alt="image" src="https://github.com/user-attachments/assets/c0b0dd53-7137-487f-9393-6810028fac7d" />
