### PR TITLE
fix cache control in tool calls

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -470,6 +470,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b8f6ee78",
+   "metadata": {},
+   "source": [
+    "If `msg` has `tool_calls`, `cache_control` is added to the last tool call (required since LiteLLM strips it from empty content blocks), otherwise to the content."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "ef65f38b",
@@ -480,20 +488,30 @@
     "def _add_cache_control(msg,          # LiteLLM formatted msg\n",
     "                       ttl=None):    # Cache TTL: '5m' (default) or '1h'\n",
     "    \"cache `msg` with default time-to-live (ttl) of 5minutes ('5m'), but can be set to '1h'.\"\n",
-    "    if isinstance(msg[\"content\"], str): \n",
-    "        msg[\"content\"] = [{\"type\": \"text\", \"text\": msg[\"content\"]}]\n",
-    "    cache_control = {\"type\": \"ephemeral\"}\n",
-    "    if ttl is not None: cache_control[\"ttl\"] = ttl\n",
-    "    if isinstance(msg[\"content\"], list) and msg[\"content\"]:\n",
-    "        msg[\"content\"][-1][\"cache_control\"] = cache_control\n",
+    "    cc = {\"type\": \"ephemeral\"} | ({\"ttl\": ttl} if ttl else {})\n",
+    "    if tcs := msg.get('tool_calls'):\n",
+    "        tcs[-1]['cache_control'] = cc\n",
+    "        return msg\n",
+    "    if not (content := msg.get(\"content\")): return msg\n",
+    "    if isinstance(content, str): msg[\"content\"] = [{\"type\": \"text\", \"text\": content}]\n",
+    "    if msg[\"content\"] and msg[\"content\"][-1].get(\"text\"):\n",
+    "        msg[\"content\"][-1][\"cache_control\"] = cc\n",
     "    return msg\n",
     "\n",
     "def _has_cache(msg):\n",
-    "    return msg[\"content\"] and isinstance(msg[\"content\"], list) and ('cache_control' in msg[\"content\"][-1])\n",
+    "    \"Check if msg has cache_control set\"\n",
+    "    if tcs := msg.get('tool_calls'): return 'cache_control' in tcs[-1]\n",
+    "    content = msg.get(\"content\")\n",
+    "    return content and isinstance(content, list) and 'cache_control' in content[-1]\n",
     "\n",
     "def remove_cache_ckpts(msg):\n",
     "    \"remove cache checkpoints and return msg.\"\n",
-    "    if _has_cache(msg): msg[\"content\"][-1].pop('cache_control', None)\n",
+    "    if not _has_cache(msg): return msg\n",
+    "    if tcs := msg.get('tool_calls'):\n",
+    "        tc = tcs[-1]\n",
+    "        if isinstance(tc, dict): tc.pop('cache_control', None)\n",
+    "        elif isinstance(tc, ChatCompletionMessageToolCall): delattr(tc, 'cache_control')\n",
+    "    elif msg.get('content'): msg[\"content\"][-1].pop('cache_control', None)\n",
     "    return msg\n",
     "\n",
     "def _mk_content(o):\n",
@@ -507,6 +525,84 @@
     "\n",
     "def stop_reason(r):\n",
     "    return r.choices[0].finish_reason"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ad8eddd",
+   "metadata": {},
+   "source": [
+    "Test with regular content message:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57ea44f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "msg_content = {'role': 'user', 'content': [{'type': 'text', 'text': 'hello'}]}\n",
+    "_add_cache_control(msg_content)\n",
+    "test_eq(msg_content['content'][-1].get('cache_control'), {'type': 'ephemeral'})\n",
+    "test_eq(_has_cache(msg_content), True)\n",
+    "remove_cache_ckpts(msg_content)\n",
+    "test_eq(_has_cache(msg_content), False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4685f8f",
+   "metadata": {},
+   "source": [
+    "Test with assistant message with tool_calls:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2dd1da17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tcs = [\n",
+    "    {'id': 'tc1', 'type': 'function', 'function': {'name': 'test', 'arguments': '{}'}},\n",
+    "    {'id': 'tc2', 'type': 'function', 'function': {'name': 'test', 'arguments': '{}'}}\n",
+    "]\n",
+    "msg_tool = {'role': 'assistant', 'content': '', 'tool_calls': tcs}\n",
+    "_add_cache_control(msg_tool)\n",
+    "test_eq(msg_tool['tool_calls'][-1].get('cache_control'), {'type': 'ephemeral'})\n",
+    "test_eq('cache_control' not in msg_tool.get('content', [{}])[-1] if msg_tool.get('content') else True, True)  # no cache in content\n",
+    "test_eq(_has_cache(msg_tool), True)\n",
+    "remove_cache_ckpts(msg_tool)\n",
+    "test_eq(_has_cache(msg_tool), False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33a67317",
+   "metadata": {},
+   "source": [
+    "Test with `ChatCompletionMessageToolCall` tool call object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbd5cae3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tcs =[\n",
+    "    ChatCompletionMessageToolCall(id='tc1', type='function', function=Function(name='test', arguments='{}')), \n",
+    "    ChatCompletionMessageToolCall(id='tc2', type='function', function=Function(name='test', arguments='{}'))\n",
+    "]\n",
+    "msg_tc_obj = {'role': 'assistant', 'content': '', 'tool_calls': tcs}\n",
+    "_add_cache_control(msg_tc_obj)\n",
+    "test_eq(getattr(msg_tc_obj['tool_calls'][-1], 'cache_control', None), {'type': 'ephemeral'})\n",
+    "test_eq(_has_cache(msg_tc_obj), True)\n",
+    "remove_cache_ckpts(msg_tc_obj)\n",
+    "test_eq(_has_cache(msg_tc_obj), False)"
    ]
   },
   {
@@ -1442,12 +1538,12 @@
        "  'tool_call_id': 'toolu_01KjnQH2Nsz2viQ7XYpLW3Ta',\n",
        "  'name': 'simple_add',\n",
        "  'content': '15'},\n",
-       " Message(content=[{'type': 'text', 'text': '', 'cache_control': {'type': 'ephemeral'}}], role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{\"a\":2,\"b\":1}', name='simple_add'), id='toolu_5EPfeJVYRn_bqR_vegJCBA', type='function')], function_call=None, provider_specific_fields=None),\n",
+       " Message(content='', role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{\"a\":2,\"b\":1}', name='simple_add'), id='toolu_5EPfeJVYRn_bqR_vegJCBA', type='function', cache_control={'type': 'ephemeral'})], function_call=None, provider_specific_fields=None),\n",
        " {'role': 'tool',\n",
        "  'tool_call_id': 'toolu_01Koi2EZrGZsBbnQ13wuuvzY',\n",
        "  'name': 'simple_add',\n",
        "  'content': '3'},\n",
-       " Message(content=[{'type': 'text', 'text': 'Now I need to multiply 15 * 3 before I can do the final division:', 'cache_control': {'type': 'ephemeral'}}], role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{\"a\":15,\"b\":3}', name='multiply'), id='toolu_I6dxGoEzSHa369zZ6HoWEw', type='function')], function_call=None, provider_specific_fields=None),\n",
+       " Message(content='Now I need to multiply 15 * 3 before I can do the final division:', role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{\"a\":15,\"b\":3}', name='multiply'), id='toolu_I6dxGoEzSHa369zZ6HoWEw', type='function', cache_control={'type': 'ephemeral'})], function_call=None, provider_specific_fields=None),\n",
        " {'role': 'tool',\n",
        "  'tool_call_id': 'toolu_0141NRaWUjmGtwxZjWkyiq6C',\n",
        "  'name': 'multiply',\n",
@@ -1473,7 +1569,7 @@
     {
      "data": {
       "text/plain": [
-       "Message(content=[{'type': 'text', 'text': 'Now I need to multiply 15 * 3 before I can do the final division:', 'cache_control': {'type': 'ephemeral'}}], role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{\"a\":15,\"b\":3}', name='multiply'), id='toolu_I6dxGoEzSHa369zZ6HoWEw', type='function')], function_call=None, provider_specific_fields=None)"
+       "Message(content='Now I need to multiply 15 * 3 before I can do the final division:', role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{\"a\":15,\"b\":3}', name='multiply'), id='toolu_I6dxGoEzSHa369zZ6HoWEw', type='function', cache_control={'type': 'ephemeral'})], function_call=None, provider_specific_fields=None)"
       ]
      },
      "execution_count": null,
@@ -1492,9 +1588,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_eq('cache_control' in msgs[0]['content'][0], True)\n",
-    "test_eq('cache_control' in msgs[-4]['content'][0], True) # shifted idxs to skip tool results but keep tool calls\n",
-    "test_eq('cache_control' in msgs[-2]['content'][0], True) # shifted idxs to skip tool results but keep tool calls"
+    "test_eq('cache_control' in msgs[0]['content'][0], True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06ef1acb",
+   "metadata": {},
+   "source": [
+    "Tool result blocks are skipped and cache control is placed into tool calls:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7bd5fc0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_eq('cache_control' in msgs[-4]['tool_calls'][0], True) \n",
+    "test_eq('cache_control' in msgs[-2]['tool_calls'][0], True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "939c493f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "L(msgs).map(remove_cache_ckpts)\n",
+    "test_eq(any(L(msgs).map(_has_cache)), False)"
    ]
   },
   {
@@ -7106,19 +7230,19 @@
       "text/markdown": [
        "Perfect! I've successfully:\n",
        "1. Called `get_config` which returned a configuration with host='localhost' and port=8080\n",
-       "2. Passed that configuration to `use_config` which confirmed it received and processed the config: \"Host: localhost, Port: 8080\"\n",
+       "2. Passed that configuration to `use_config` which processed it and confirmed the settings: Host: localhost, Port: 8080\n",
        "\n",
        "<details>\n",
        "\n",
        "- id: `chatcmpl-xxx`\n",
        "- model: `claude-sonnet-4-5-20250929`\n",
        "- finish_reason: `stop`\n",
-       "- usage: `Usage(completion_tokens=65, prompt_tokens=952, total_tokens=1017, completion_tokens_details=None, prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=None, cached_tokens=0, text_tokens=None, image_tokens=None, cache_creation_tokens=0, cache_creation_token_details=CacheCreationTokenDetails(ephemeral_5m_input_tokens=0, ephemeral_1h_input_tokens=0)), cache_creation_input_tokens=0, cache_read_input_tokens=0)`\n",
+       "- usage: `Usage(completion_tokens=62, prompt_tokens=946, total_tokens=1008, completion_tokens_details=None, prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=None, cached_tokens=0, text_tokens=None, image_tokens=None, cache_creation_tokens=0, cache_creation_token_details=CacheCreationTokenDetails(ephemeral_5m_input_tokens=0, ephemeral_1h_input_tokens=0)), cache_creation_input_tokens=0, cache_read_input_tokens=0)`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ModelResponse(id='chatcmpl-xxx', created=1000000000, model='claude-sonnet-4-5-20250929', object='chat.completion', system_fingerprint=None, choices=[Choices(finish_reason='stop', index=0, message=Message(content='Perfect! I\\'ve successfully:\\n1. Called `get_config` which returned a configuration with host=\\'localhost\\' and port=8080\\n2. Passed that configuration to `use_config` which confirmed it received and processed the config: \"Host: localhost, Port: 8080\"', role='assistant', tool_calls=None, function_call=None, provider_specific_fields={'citations': None, 'thinking_blocks': None}))], usage=Usage(completion_tokens=65, prompt_tokens=952, total_tokens=1017, completion_tokens_details=None, prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=None, cached_tokens=0, text_tokens=None, image_tokens=None, cache_creation_tokens=0, cache_creation_token_details=CacheCreationTokenDetails(ephemeral_5m_input_tokens=0, ephemeral_1h_input_tokens=0)), cache_creation_input_tokens=0, cache_read_input_tokens=0))"
+       "ModelResponse(id='chatcmpl-xxx', created=1000000000, model='claude-sonnet-4-5-20250929', object='chat.completion', system_fingerprint=None, choices=[Choices(finish_reason='stop', index=0, message=Message(content=\"Perfect! I've successfully:\\n1. Called `get_config` which returned a configuration with host='localhost' and port=8080\\n2. Passed that configuration to `use_config` which processed it and confirmed the settings: Host: localhost, Port: 8080\", role='assistant', tool_calls=None, function_call=None, provider_specific_fields={'citations': None, 'thinking_blocks': None}))], usage=Usage(completion_tokens=62, prompt_tokens=946, total_tokens=1008, completion_tokens_details=None, prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=None, cached_tokens=0, text_tokens=None, image_tokens=None, cache_creation_tokens=0, cache_creation_token_details=CacheCreationTokenDetails(ephemeral_5m_input_tokens=0, ephemeral_1h_input_tokens=0)), cache_creation_input_tokens=0, cache_read_input_tokens=0))"
       ]
      },
      "execution_count": null,
@@ -7140,8 +7264,8 @@
     {
      "data": {
       "text/plain": [
-       "{'toolu_wJ_Nj3OcRIiGm9vS5yu1tw': {'host': 'localhost', 'port': 8080},\n",
-       " 'toolu_f0Ef7R5wR5mzodHCrUqxVQ': 'Host: localhost, Port: 8080'}"
+       "{'toolu_0m1TlhBYToydcXPlW8f96w': {'host': 'localhost', 'port': 8080},\n",
+       " 'toolu_BxIJEbO2S1eaVPJn3ROCZg': 'Host: localhost, Port: 8080'}"
       ]
      },
      "execution_count": null,
@@ -7210,10 +7334,10 @@
        "    'text': 'Use a tool',\n",
        "    'cache_control': {'type': 'ephemeral'}}]},\n",
        " {'role': 'assistant',\n",
-       "  'content': [{'type': 'text',\n",
-       "    'text': '',\n",
-       "    'cache_control': {'type': 'ephemeral'}}],\n",
-       "  'tool_calls': [{'id': '1', 'function': {'name': 'foo', 'arguments': '{}'}}]},\n",
+       "  'content': '',\n",
+       "  'tool_calls': [{'id': '1',\n",
+       "    'function': {'name': 'foo', 'arguments': '{}'},\n",
+       "    'cache_control': {'type': 'ephemeral'}}]},\n",
        " {'role': 'tool', 'tool_call_id': '1', 'content': 'result'}]"
       ]
      },
@@ -7229,12 +7353,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f47ca9cd",
+   "id": "4f607408",
    "metadata": {},
    "outputs": [],
    "source": [
     "test_eq('cache_control' in c.hist[-3]['content'][0], True)  # user msg\n",
-    "test_eq('cache_control' in c.hist[-2]['content'][0], True)  # tool call msg"
+    "test_eq('cache_control' in c.hist[-2]['tool_calls'][-1], True)  # tool call msg"
    ]
   },
   {
@@ -7643,7 +7767,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'tool_call_id': 'call_fOcbSPulTlmYozc2_RrHzg', 'role': 'tool', 'name': 'async_add', 'content': '12'}\n",
+      "{'tool_call_id': 'call_XJSTgWDGQ_21WjrBMq4qIA', 'role': 'tool', 'name': 'async_add', 'content': '12'}\n",
       "I used the calculator tool to add 5 and 7. The result is 12."
      ]
     }
@@ -7674,7 +7798,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ModelResponse(id='chatcmpl-xxx', created=1000000000, model='claude-sonnet-4-5', object='chat.completion', system_fingerprint=None, choices=[Choices(finish_reason='tool_calls', index=0, message=Message(content=\"I'll calculate ((10 + 5) * 3) / (2 + 1) step by step:\", role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{\"a\": 10, \"b\": 5}', name='simple_add'), id='toolu_o2vLAWfpQ2OQXAU7Jf2svg', type='function'), ChatCompletionMessageToolCall(function=Function(arguments='{\"a\": 2, \"b\": 1}', name='simple_add'), id='toolu_hW89leCuShusWWIWrg_byA', type='function')], function_call=None, provider_specific_fields=None))], usage=Usage(completion_tokens=228, prompt_tokens=794, total_tokens=1022, completion_tokens_details=None, prompt_tokens_details=None))\n"
+      "ModelResponse(id='chatcmpl-xxx', created=1000000000, model='claude-sonnet-4-5', object='chat.completion', system_fingerprint=None, choices=[Choices(finish_reason='tool_calls', index=0, message=Message(content=\"I'll calculate ((10 + 5) * 3) / (2 + 1) step by step:\", role='assistant', tool_calls=[ChatCompletionMessageToolCall(function=Function(arguments='{\"a\": 10, \"b\": 5}', name='simple_add'), id='toolu_GtCm8ia9SXSTtWSwi_BMPg', type='function'), ChatCompletionMessageToolCall(function=Function(arguments='{\"a\": 2, \"b\": 1}', name='simple_add'), id='toolu_fOcbSPulTlmYozc2_RrHzg', type='function')], function_call=None, provider_specific_fields=None))], usage=Usage(completion_tokens=228, prompt_tokens=794, total_tokens=1022, completion_tokens_details=None, prompt_tokens_details=None))\n"
      ]
     }
    ],
@@ -7692,7 +7816,7 @@
     {
      "data": {
       "text/plain": [
-       "ChatCompletionMessageToolCall(function=Function(arguments='{\"a\": 10, \"b\": 5}', name='simple_add'), id='toolu_o2vLAWfpQ2OQXAU7Jf2svg', type='function')"
+       "ChatCompletionMessageToolCall(function=Function(arguments='{\"a\": 10, \"b\": 5}', name='simple_add'), id='toolu_GtCm8ia9SXSTtWSwi_BMPg', type='function')"
       ]
      },
      "execution_count": null,
@@ -7952,7 +8076,7 @@
       "\n",
       "```json\n",
       "{\n",
-      "  \"id\": \"toolu_40WscurDQgSt587zftLsLw\",\n",
+      "  \"id\": \"toolu_o2vLAWfpQ2OQXAU7Jf2svg\",\n",
       "  \"call\": {\n",
       "    \"function\": \"simple_add\",\n",
       "    \"arguments\": {\n",
@@ -8084,7 +8208,7 @@
        "\n",
        "```json\n",
        "{\n",
-       "  \"id\": \"call_3_xGI6uJRgWik5s7f6dNig\",\n",
+       "  \"id\": \"call_40WscurDQgSt587zftLsLw\",\n",
        "  \"call\": {\n",
        "    \"function\": \"simple_add\",\n",
        "    \"arguments\": {\n",
@@ -8130,7 +8254,7 @@
        "\n",
        "```json\n",
        "{\n",
-       "  \"id\": \"call_tKHKeVcYTaKCfAE_OAGDmQ\",\n",
+       "  \"id\": \"call_3_xGI6uJRgWik5s7f6dNig\",\n",
        "  \"call\": {\n",
        "    \"function\": \"async_add\",\n",
        "    \"arguments\": {\n",
@@ -8176,7 +8300,7 @@
        "\n",
        "```json\n",
        "{\n",
-       "  \"id\": \"call_hm1wAgkUQq2SYx250XA0zg\",\n",
+       "  \"id\": \"call_tKHKeVcYTaKCfAE_OAGDmQ\",\n",
        "  \"call\": {\n",
        "    \"function\": \"async_add\",\n",
        "    \"arguments\": {\n",
@@ -8271,7 +8395,7 @@
        "\n",
        "```json\n",
        "{\n",
-       "  \"id\": \"call_tNTfzLfXScyLXKQ2lTwXjg\",\n",
+       "  \"id\": \"call_mkMfekHDQ1mf3iKBJftfPQ\",\n",
        "  \"call\": {\n",
        "    \"function\": \"simple_add\",\n",
        "    \"arguments\": {\n",
@@ -8292,7 +8416,7 @@
        "\n",
        "```json\n",
        "{\n",
-       "  \"id\": \"call_zMk_9xD8SX24bjDvzpsucA\",\n",
+       "  \"id\": \"call_YQZ6jNejSDyn6WniyL8j_w\",\n",
        "  \"call\": {\n",
        "    \"function\": \"simple_add\",\n",
        "    \"arguments\": {\n",
@@ -8313,7 +8437,7 @@
        "\n",
        "```json\n",
        "{\n",
-       "  \"id\": \"call_wkcv1gPpSgKM6i3wCmbcTg\",\n",
+       "  \"id\": \"call_6l8ktt5vTEuEOyp9FassIQ\",\n",
        "  \"call\": {\n",
        "    \"function\": \"multiply\",\n",
        "    \"arguments\": {\n",
@@ -8334,7 +8458,7 @@
        "\n",
        "```json\n",
        "{\n",
-       "  \"id\": \"call_3KWzU1ShRQWy1rwg2A1qHA\",\n",
+       "  \"id\": \"call_IWgQgTmfSo_Q_J7uChcn9w\",\n",
        "  \"call\": {\n",
        "    \"function\": \"divide\",\n",
        "    \"arguments\": {\n",
@@ -8385,7 +8509,7 @@
     {
      "data": {
       "text/plain": [
-       "Message(content=\"Of course, let's break this down.\\n\\nFirst, we will evaluate the two sums in the expression, `10 + 5` and `2 + 1`, in parallel.\", role='assistant', tool_calls=[{'function': {'arguments': '{\"a\": 10, \"b\": 5}', 'name': 'simple_add'}, 'id': 'call_tNTfzLfXScyLXKQ2lTwXjg', 'type': 'function'}, {'function': {'arguments': '{\"b\": 1, \"a\": 2}', 'name': 'simple_add'}, 'id': 'call_zMk_9xD8SX24bjDvzpsucA', 'type': 'function'}], function_call=None, provider_specific_fields=None)"
+       "Message(content=\"Of course, let's break this down.\\n\\nFirst, we will evaluate the two sums in the expression, `10 + 5` and `2 + 1`, in parallel.\", role='assistant', tool_calls=[{'function': {'arguments': '{\"a\": 10, \"b\": 5}', 'name': 'simple_add'}, 'id': 'call_mkMfekHDQ1mf3iKBJftfPQ', 'type': 'function'}, {'function': {'arguments': '{\"b\": 1, \"a\": 2}', 'name': 'simple_add'}, 'id': 'call_YQZ6jNejSDyn6WniyL8j_w', 'type': 'function'}], function_call=None, provider_specific_fields=None)"
       ]
      },
      "execution_count": null,
@@ -8406,7 +8530,7 @@
     {
      "data": {
       "text/plain": [
-       "{'tool_call_id': 'call_tNTfzLfXScyLXKQ2lTwXjg',\n",
+       "{'tool_call_id': 'call_mkMfekHDQ1mf3iKBJftfPQ',\n",
        " 'role': 'tool',\n",
        " 'name': 'simple_add',\n",
        " 'content': '15'}"
@@ -8430,7 +8554,7 @@
     {
      "data": {
       "text/plain": [
-       "{'tool_call_id': 'call_zMk_9xD8SX24bjDvzpsucA',\n",
+       "{'tool_call_id': 'call_YQZ6jNejSDyn6WniyL8j_w',\n",
        " 'role': 'tool',\n",
        " 'name': 'simple_add',\n",
        " 'content': '3'}"
@@ -8454,7 +8578,7 @@
     {
      "data": {
       "text/plain": [
-       "Message(content='Now that we have the results for the two sums, we can proceed with the next step. We have calculated that `10 + 5 = 15` and `2 + 1 = 3`. The expression is now `15 * 3 / 3`. We will now perform the multiplication and division in parallel.', role='assistant', tool_calls=[{'function': {'arguments': '{\"a\": 15, \"b\": 3}', 'name': 'multiply'}, 'id': 'call_wkcv1gPpSgKM6i3wCmbcTg', 'type': 'function'}, {'function': {'arguments': '{\"a\": 15, \"b\": 3}', 'name': 'divide'}, 'id': 'call_3KWzU1ShRQWy1rwg2A1qHA', 'type': 'function'}], function_call=None, provider_specific_fields=None)"
+       "Message(content='Now that we have the results for the two sums, we can proceed with the next step. We have calculated that `10 + 5 = 15` and `2 + 1 = 3`. The expression is now `15 * 3 / 3`. We will now perform the multiplication and division in parallel.', role='assistant', tool_calls=[{'function': {'arguments': '{\"a\": 15, \"b\": 3}', 'name': 'multiply'}, 'id': 'call_6l8ktt5vTEuEOyp9FassIQ', 'type': 'function'}, {'function': {'arguments': '{\"a\": 15, \"b\": 3}', 'name': 'divide'}, 'id': 'call_IWgQgTmfSo_Q_J7uChcn9w', 'type': 'function'}], function_call=None, provider_specific_fields=None)"
       ]
      },
      "execution_count": null,
@@ -8475,7 +8599,7 @@
     {
      "data": {
       "text/plain": [
-       "{'tool_call_id': 'call_wkcv1gPpSgKM6i3wCmbcTg',\n",
+       "{'tool_call_id': 'call_6l8ktt5vTEuEOyp9FassIQ',\n",
        " 'role': 'tool',\n",
        " 'name': 'multiply',\n",
        " 'content': '45'}"
@@ -8640,23 +8764,23 @@
        "\n",
        "[*](https://www.answer.ai/posts/2025-10-01-solveit-full.html \"Launching Solveit, the antidote to AI fatigue – Answer.AI\") The approach is inspired by George Polya, a Hungarian mathematician who wrote the influential book \"How to Solve It\" in 1945, which outlines a four-step problem-solving framework including understanding the problem, devising a plan, and breaking down problems into manageable parts.\n",
        "\n",
-       "## The Team\n",
-       "\n",
-       "[*](https://www.producthunt.com/products/solveit \"solveit: New course and AI platform from Jeremy Howard and Eric Ries | Product Hunt\") Solveit was created by Jeremy Howard (co-founder of fast.ai) and Eric Ries (of Lean Startup fame) through their AI research lab called Answer.AI.\n",
-       "\n",
-       "## The Approach\n",
+       "## The Solveit Method\n",
        "\n",
        "[*](https://www.answer.ai/posts/2024-11-07-solveit.html \"A New Chapter for fast.ai: How To Solve It With Code – Answer.AI\") Instead of asking AI to generate hundreds of lines of code at once, you work together in small steps - you might write a line or two, then have the AI suggest the next piece. [*](https://solve.it.com/ \"Solve It With Code\") The philosophy is: don't outsource your thinking to AI; instead, use AI to become a better problem solver, clearer thinker, and more elegant coder.\n",
        "\n",
-       "## Course Content\n",
+       "## Who Created It?\n",
        "\n",
-       "[*](https://solve.it.com/ \"Solve It With Code\") Across 10 lessons, the course covers classic data structures and algorithms, web programming using FastHTML, writing (including long form writing with Eric Ries), reading academic papers, and building startups.\n",
+       "[*](https://www.producthunt.com/products/solveit \"solveit: New course and AI platform from Jeremy Howard and Eric Ries | Product Hunt\") Jeremy Howard and Eric Ries created Answer.AI, the AI research lab behind Solveit. [*](https://www.answer.ai/posts/2024-11-07-solveit.html \"A New Chapter for fast.ai: How To Solve It With Code – Answer.AI\") fast.ai is joining Answer.AI, marking a new phase in making AI accessible to everyone.\n",
+       "\n",
+       "## The Course\n",
+       "\n",
+       "[*](https://solve.it.com/ \"Solve It With Code\") Across 10 lessons, the course covers classic data structures and algorithms, web programming using FastHTML, writing (including with Eric Ries), reading academic papers, and building startups. [*](https://www.fast.ai/posts/2025-10-15-solveit2.html \"How to Solve it With Code course now available – fast.ai\") It's designed mainly for experienced coders, AI practitioners, and data scientists.\n",
        "\n",
        "## Pricing\n",
        "\n",
        "[*](https://solve.it.com/ \"Solve It With Code\") The course fee includes access to the Solveit platform (with no quotas) for 30 days, after which you can subscribe for $10/month to maintain access.\n",
        "\n",
-       "The platform has been used internally at Answer.AI for various tasks and [*](https://www.answer.ai/posts/2025-10-01-solveit-full.html \"Launching Solveit, the antidote to AI fatigue – Answer.AI\") hundreds of users from a preview course say it's changed their lives."
+       "The platform has been used internally at Answer.AI for various tasks and received positive feedback from preview users who say it's changed how they approach problem-solving with AI."
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -8716,23 +8840,23 @@
       "text/markdown": [
        "Perfect! I successfully completed both steps:\n",
        "\n",
-       "1. **Retrieved person data**: I called `get_person` which returned information about Alice, who is 30 years old.\n",
+       "1. **Retrieved person data**: I called `get_person` which returned a person named Alice who is 30 years old.\n",
        "\n",
        "2. **Greeted the person**: I then passed Alice's data to `greet_person`, which generated the greeting: \"Hello Alice, you are 30 years old!\"\n",
        "\n",
-       "The task has been completed successfully. The person's data was retrieved and used to create a personalized greeting.\n",
+       "The task has been completed successfully. The person's information was retrieved and used to create a personalized greeting.\n",
        "\n",
        "<details>\n",
        "\n",
        "- id: `chatcmpl-xxx`\n",
        "- model: `claude-sonnet-4-5-20250929`\n",
        "- finish_reason: `stop`\n",
-       "- usage: `Usage(completion_tokens=103, prompt_tokens=1083, total_tokens=1186, completion_tokens_details=None, prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=None, cached_tokens=0, text_tokens=None, image_tokens=None, cache_creation_tokens=0, cache_creation_token_details=CacheCreationTokenDetails(ephemeral_5m_input_tokens=0, ephemeral_1h_input_tokens=0)), cache_creation_input_tokens=0, cache_read_input_tokens=0)`\n",
+       "- usage: `Usage(completion_tokens=103, prompt_tokens=1077, total_tokens=1180, completion_tokens_details=None, prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=None, cached_tokens=0, text_tokens=None, image_tokens=None, cache_creation_tokens=0, cache_creation_token_details=CacheCreationTokenDetails(ephemeral_5m_input_tokens=0, ephemeral_1h_input_tokens=0)), cache_creation_input_tokens=0, cache_read_input_tokens=0)`\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ModelResponse(id='chatcmpl-xxx', created=1000000000, model='claude-sonnet-4-5-20250929', object='chat.completion', system_fingerprint=None, choices=[Choices(finish_reason='stop', index=0, message=Message(content='Perfect! I successfully completed both steps:\\n\\n1. **Retrieved person data**: I called `get_person` which returned information about Alice, who is 30 years old.\\n\\n2. **Greeted the person**: I then passed Alice\\'s data to `greet_person`, which generated the greeting: \"Hello Alice, you are 30 years old!\"\\n\\nThe task has been completed successfully. The person\\'s data was retrieved and used to create a personalized greeting.', role='assistant', tool_calls=None, function_call=None, provider_specific_fields={'citations': None, 'thinking_blocks': None}))], usage=Usage(completion_tokens=103, prompt_tokens=1083, total_tokens=1186, completion_tokens_details=None, prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=None, cached_tokens=0, text_tokens=None, image_tokens=None, cache_creation_tokens=0, cache_creation_token_details=CacheCreationTokenDetails(ephemeral_5m_input_tokens=0, ephemeral_1h_input_tokens=0)), cache_creation_input_tokens=0, cache_read_input_tokens=0))"
+       "ModelResponse(id='chatcmpl-xxx', created=1000000000, model='claude-sonnet-4-5-20250929', object='chat.completion', system_fingerprint=None, choices=[Choices(finish_reason='stop', index=0, message=Message(content='Perfect! I successfully completed both steps:\\n\\n1. **Retrieved person data**: I called `get_person` which returned a person named Alice who is 30 years old.\\n\\n2. **Greeted the person**: I then passed Alice\\'s data to `greet_person`, which generated the greeting: \"Hello Alice, you are 30 years old!\"\\n\\nThe task has been completed successfully. The person\\'s information was retrieved and used to create a personalized greeting.', role='assistant', tool_calls=None, function_call=None, provider_specific_fields={'citations': None, 'thinking_blocks': None}))], usage=Usage(completion_tokens=103, prompt_tokens=1077, total_tokens=1180, completion_tokens_details=None, prompt_tokens_details=PromptTokensDetailsWrapper(audio_tokens=None, cached_tokens=0, text_tokens=None, image_tokens=None, cache_creation_tokens=0, cache_creation_token_details=CacheCreationTokenDetails(ephemeral_5m_input_tokens=0, ephemeral_1h_input_tokens=0)), cache_creation_input_tokens=0, cache_read_input_tokens=0))"
       ]
      },
      "execution_count": null,
@@ -8754,8 +8878,8 @@
     {
      "data": {
       "text/plain": [
-       "{'toolu_HGpLXn2FRyWHB675xsN0TA': {'name': 'Alice', 'age': 30},\n",
-       " 'toolu_s2jFU5wwTqqPZrMt4ZtYNw': 'Hello Alice, you are 30 years old!'}"
+       "{'toolu_piRbWYyUT5izOGw_GvR4fw': {'name': 'Alice', 'age': 30},\n",
+       " 'toolu_yI4DtmInTLyx6cqAWL87ng': 'Hello Alice, you are 30 years old!'}"
       ]
      },
      "execution_count": null,
@@ -8778,12 +8902,12 @@
       "text/plain": [
        "[[{'index': 1,\n",
        "   'function': {'arguments': '{}', 'name': 'get_person'},\n",
-       "   'id': 'toolu_HGpLXn2FRyWHB675xsN0TA',\n",
+       "   'id': 'toolu_piRbWYyUT5izOGw_GvR4fw',\n",
        "   'type': 'function'}],\n",
        " [{'index': 1,\n",
-       "   'function': {'arguments': '{\"person\": \"$`toolu_HGpLXn2FRyWHB675xsN0TA`\"}',\n",
+       "   'function': {'arguments': '{\"person\": \"$`toolu_piRbWYyUT5izOGw_GvR4fw`\"}',\n",
        "    'name': 'greet_person'},\n",
-       "   'id': 'toolu_s2jFU5wwTqqPZrMt4ZtYNw',\n",
+       "   'id': 'toolu_yI4DtmInTLyx6cqAWL87ng',\n",
        "   'type': 'function'}]]"
       ]
      },


### PR DESCRIPTION
Fixes https://github.com/AnswerDotAI/lisette/issues/106

This PR fixes cache control being stripped from assistant messages with tool calls when using LiteLLM.

**Problem:** LiteLLM's `convert_to_anthropic_tool_invoke` looks for `cache_control` in the tool call object, not in the message content. Since lisette was adding `cache_control` to empty content blocks, it was being stripped during transformation.

**Changes:**
- Updated `_add_cache_control` to add `cache_control` to `tool_calls[-1]` when present, otherwise to content
- Updated `_has_cache` to check for `cache_control` in tool_calls
- Updated `remove_cache_ckpts` to handle removal from tool_calls
- Simplified all three functions using early returns and walrus operator

## Before

Tooloops with > 3 tool calls were resulting in sudden cache hit drops. 

<img width="1424" height="1210" alt="image" src="https://github.com/user-attachments/assets/7894a3df-dda8-4d1e-be75-030de67acb0a" />

## After

Now cache hit rate is consistently high during the tooloop.

<img width="1005" height="430" alt="image" src="https://github.com/user-attachments/assets/6a173f06-2c1f-445b-a397-f7cfaa0530cd" />
