### PR TITLE
Codex auth

### DIFF
--- a/lisette/__init__.py
+++ b/lisette/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.1.24"
+__version__ = "0.1.25"
 from .core import *

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -10488,6 +10488,7 @@
     }
    ],
    "source": [
+    "#| eval: false\n",
     "cc.use"
    ]
   },

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -10137,6 +10137,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "defb4890",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from litellm.llms.chatgpt.authenticator import Authenticator, GetAccessTokenError\n",
+    "\n",
+    "@patch\n",
+    "def _login_device_code(self:Authenticator):\n",
+    "    raise GetAccessTokenError(status_code=401, message=\"No Codex auth found — skipping device code login to avoid auth loop\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "3c26336b",
    "metadata": {},
    "outputs": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ license = {text = "Apache-2.0"}
 authors = [{name = "AnswerDotAI", email = "support@answer.ai"}]
 keywords = ['nbdev', 'jupyter', 'notebook', 'python']
 classifiers = ["Natural Language :: English", "Intended Audience :: Developers", "Development Status :: 3 - Alpha", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3 :: Only"]
-dependencies = ['litellm', 'numpydoc', 'toolslm>=0.3.29', 'fastcore>=1.12.40']
+dependencies = ['litellm', 'numpydoc', 'toolslm>=0.3.29', 'fastcore>=1.12.40', "tenacity>=9.1.4",
+]
 
 [project.urls]
 Repository = "https://github.com/AnswerDotAI/lisette"


### PR DESCRIPTION
Codex triggers an interctive auth message if the credentials are not found. This patch makes it raise an Exception instead. Tenacity is a dependency used by retries. We could avoid using that, but then the patch would be uglier and considering we might migrate into fastllm soon I though it was a decent trade-off.