### PR TITLE
Export types module from package root

### DIFF
--- a/lisette/__init__.py
+++ b/lisette/__init__.py
@@ -1,2 +1,3 @@
 __version__ = "0.1.32"
+from .types import *
 from .core import *


### PR DESCRIPTION
Small fix as it without it tests in solveit were broken. We thought it was most convenient to export these types by default.