### PR TITLE
fix truncation

### DIFF
--- a/lisette/core.py
+++ b/lisette/core.py
@@ -437,7 +437,7 @@ def _has_stop(results): return any(isinstance(r.get('content'), StopResponse) fo
 def _trunc_str(s, mx=2000, skip=10, replace="TRUNCATED"):
     "Truncate `s` to `mx` chars max, adding `replace` if truncated"
     if not isinstance(s, str): s = str(s)
-    s = s.rstrip()
+    s = s.rstrip() if type(s) is str else type(s)(s.rstrip())
     if len(s)>2 and s[0]=='𝍁' and s[-1]=='𝍁':
         s = s[1:-1]
         if replace: return s

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -265,7 +265,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ms = [\"gemini/gemini-3-pro-preview\", \"gemini/gemini-3-flash-preview\", sonn, \"openai/gpt-5.4\"]\n",
+    "ms = [\"gemini/gemini-3.1-pro-preview\", \"gemini/gemini-3-flash-preview\", sonn, \"openai/gpt-5.4\"]\n",
     "model = ms[2]"
    ]
   },
@@ -3506,7 +3506,7 @@
     "def _trunc_str(s, mx=2000, skip=10, replace=\"TRUNCATED\"):\n",
     "    \"Truncate `s` to `mx` chars max, adding `replace` if truncated\"\n",
     "    if not isinstance(s, str): s = str(s)\n",
-    "    s = s.rstrip()\n",
+    "    s = s.rstrip() if type(s) is str else type(s)(s.rstrip())\n",
     "    if len(s)>2 and s[0]=='𝍁' and s[-1]=='𝍁':\n",
     "        s = s[1:-1]\n",
     "        if replace: return s\n",
@@ -3540,10 +3540,11 @@
     }
    ],
    "source": [
-    "print(_trunc_str('𝍁xxxxxxxxxx𝍁', mx=5))\n",
-    "print(_trunc_str(Safe('xxxxxxxxxx'), mx=5))\n",
-    "print(_trunc_str('xxxxxxxxxx', mx=5, skip=0))\n",
-    "print(_trunc_str('xxxxxxxxxx', mx=5, skip=1))"
+    "test_eq(_trunc_str('𝍁xxxxxxxxxx𝍁', mx=5), 'xxxxxxxxxx')\n",
+    "test_eq(_trunc_str(Safe('xxxxxxxxxx'), mx=5), 'xxxxxxxxxx')\n",
+    "test_eq(_trunc_str(FullResponse('xxxxxxxxxx'), mx=5), 'xxxxxxxxxx')\n",
+    "test_eq(_trunc_str('xxxxxxxxxx', mx=5, skip=0), '<TRUNCATED>xxxxx…</TRUNCATED>')\n",
+    "test_eq(_trunc_str('xxxxxxxxxx', mx=5, skip=1), '<TRUNCATED>…xxx…</TRUNCATED>')"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes response truncation. The issue was that `s.rstrip()` always returned a `str` even though `s` could be a subclass of `str` such as `FullResponse` or `Safe`.  I also added some tests.

I also updated the gemini test model as i got an error that the previous one doesnt exist anymore when running the tests locally.

I've made an identical PR to fastllm.